### PR TITLE
feat: add proxy factory

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,16 @@
-module.exports = new Proxy({}, {
-  get: (_, bin) => function (...args) {
-    const out = require('child_process').spawnSync(bin, args, {...this})
-    return Object.assign(new String(out.stdout), out)
+const cp = require('child_process')
+
+module.exports = new Proxy(function() {}, {
+  apply(target, thisArg, argArray) {
+    return new Proxy(argArray[0] || {}, {
+      get: (target, bin) => function (...args) {
+        const self = this.__proto__ === Object.prototype ? {...this} : target
+        const out = cp.spawnSync(bin, args, self)
+        return Object.assign(new String(out.stdout), out)
+      }
+    })
+  },
+  get(t, key) {
+    return module.exports()[key]
   }
 })

--- a/index.js
+++ b/index.js
@@ -1,16 +1,12 @@
 const cp = require('child_process')
 
-module.exports = new Proxy(function() {}, {
-  apply(target, thisArg, argArray) {
-    return new Proxy(argArray[0] || {}, {
+module.exports = new Proxy(() => {}, {
+  apply: (target, thisArg, [defaults = {}]) =>
+    new Proxy(defaults, {
       get: (target, bin) => function (...args) {
-        const self = this.__proto__ === Object.prototype ? {...this} : target
-        const out = cp.spawnSync(bin, args, self)
+        const out = cp.spawnSync(bin, args, this.__proto__ === Object.prototype ? this : target)
         return Object.assign(new String(out.stdout), out)
       }
-    })
-  },
-  get(t, key) {
-    return module.exports()[key]
-  }
+    }),
+  get: (_, key) => module.exports()[key]
 })

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tiny spawn wrapper",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "PATH=$(env -i bash -c 'echo $PATH') ln -fs /bin/echo $(pwd)/node_modules/.bin/e && node test.js && rm $(pwd)/node_modules/.bin/e"
   },
   "files": [
     "index.js"

--- a/test.js
+++ b/test.js
@@ -1,6 +1,57 @@
 const assert = require('assert/strict')
 const {echo, tr, grep} = require('.')
+const process = require('process')
+const path = require('path')
+const url = require('url')
 
 assert.equal(echo('foo').toString(), 'foo\n')
 assert.equal(tr.call({input: 'bar'}, '[a-z]', '[A-Z]').toString(), 'BAR')
 assert.equal(grep('something', 'somewhere').status, 2)
+
+assert.equal(require('.').pwd().toString().trim(), process.cwd())
+assert.equal(require('.')({cwd: '/private/tmp'}).pwd().toString().trim(), '/private/tmp')
+
+const env = npmRunPathEnv()
+const {e: e_} = require('.')({env})
+const {e} = require('.')
+require('.').env = env
+
+// Adapted from:
+// https://github.com/sindresorhus/path-key/blob/main/index.js
+// https://github.com/sindresorhus/npm-run-path/blob/main/index.js
+function pathKey({env} = {}) {
+  if (process.platform !== 'win32') return 'PATH'
+  return Object.keys(env).reverse().find(key => key.toUpperCase() === 'PATH') || 'Path'
+}
+
+function npmRunPath(path_ = process.env[pathKey()]) {
+  const cwd = process.cwd()
+  const execPath = process.execPath
+
+  let previous
+  const cwdString = cwd instanceof URL ? url.fileURLToPath(cwd) : cwd
+  let cwdPath = path.resolve(cwdString)
+  const result = []
+
+  while (previous !== cwdPath) {
+    result.push(path.join(cwdPath, 'node_modules/.bin'))
+    previous = cwdPath
+    cwdPath = path.resolve(cwdPath, '..')
+  }
+
+  // Ensure the running `node` binary is used.
+  result.push(path.resolve(cwdString, execPath, '..'))
+
+  return [...result, path_].join(path.delimiter)
+}
+
+function npmRunPathEnv() {
+  const env = {...process.env}
+  const path = pathKey({env})
+  env[path] = npmRunPath(env[path])
+
+  return env
+}
+
+assert.equal(e('foo').toString(), 'foo\n')
+assert.equal(e_('foo').toString(), 'foo\n')

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
 const assert = require('assert/strict')
-const {echo, tr, grep} = require('.')
 const process = require('process')
 const path = require('path')
 const url = require('url')
+const {echo, tr, grep} = require('.')
 
 assert.equal(echo('foo').toString(), 'foo\n')
 assert.equal(tr.call({input: 'bar'}, '[a-z]', '[A-Z]').toString(), 'BAR')


### PR DESCRIPTION
```js
const {git, npm} = require('tinysh')({ cwd: 'foo/packages/bar' })

git('add .')
git('commit -m "foo"')
git('push origin HEAD:refs/heads/master')

npm('publish')
```

instead of
```js
const {git, npm} = require('tinysh')

git.call({cwd}, 'add .')
git.call({cwd}, commit -m "foo"')
git.call({cwd}, 'push origin HEAD:refs/heads/master')

npm.call({cwd}, 'publish')
```